### PR TITLE
Fix browser WebSocket event handling

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -79,7 +79,7 @@ export default class JPCWebSocket extends JPCProtocol {
     if (typeof (window) != "undefined") { // browser
       webSocket = new WebSocket(url);
       webSocket.on = (eventName, func) => {
-        webSocket.addEventListener(eventName, func, false);
+        webSocket.addEventListener(eventName, message => func(message.data), false);
       };
     } else { // node.js
       webSocket = new WebSocketNode(url);


### PR DESCRIPTION
Node's `ws` package's `message` event just passes the `data`, so we need to do the same for browser-based `WebSocket`.