### PR TITLE
Test fixes

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -79,7 +79,7 @@ export default class JPCWebSocket extends JPCProtocol {
     if (typeof (window) != "undefined") { // browser
       webSocket = new WebSocket(url);
       webSocket.on = (eventName, func) => {
-        webSocket.addEventListener(eventName, func, false);
+        webSocket.addEventListener(eventName, message => func(message.data), false);
       };
     } else { // node.js
       webSocket = new WebSocketNode(url);

--- a/protocol.js
+++ b/protocol.js
@@ -2,7 +2,6 @@ import WSCall from "./WSCall.js";
 import JPCProtocol from "jpc-core/protocol.js";
 import WebSocketNode from "ws";
 import { assert } from "jpc-core/util.js";
-import { consoleError } from "../jpc-core/util.js";
 
 /**
  * Wire protocol API
@@ -115,22 +114,14 @@ export default class JPCWebSocket extends JPCProtocol {
    * Implements the wire protocol.
    *
    * @param method {string} the message name, e.g. "func", "get" etc.
-   * @param responseMethod {string} (optional)
-   *    if given, wait for the remote side to respond with this method,
-   *    and return the payload of `responseMethod`.
    * @param payload {JSON} see value in PROTOCOL.md
    * @returns {any} see value in PROTOCOL.md
-   *   The payload of the corresponding `responseMethod` answer.
-   *   If `responseMethod` is not given, returns null/undefined.
+   *   The payload of the corresponding answer.
    * @throws {Error} if:
    *   - the remote end threw an exception
    *   - the connection disappeared
    */
-  async callRemote(method, responseMethod, payload) {
-    if (responseMethod) {
-      return await this._wsCall.makeCall(method, payload);
-    } else {
-      return this._wsCall.makeCall(method, payload).catch(consoleError);
-    }
+  async callRemote(method, payload) {
+    return this._wsCall.makeCall(method, payload);
   }
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,6 @@
-import { expect, expectTypeOf, test, beforeAll, afterAll } from 'vitest';
+import { expect, test, beforeAll, afterAll } from 'vitest';
 import JPCWebSocket from "../protocol.js";
-import { start as startServer, kPort } from './server';
+import { start as startServer, stop as stopServer, kPort } from './server';
 
 let jpc;
 let app;
@@ -13,14 +13,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  app.exit();
+  stopServer();
 });
 
 test('Car class', async () => {
   let cars = await app.cars;
   for (let car of cars) {
     let owner = await car.owner;
-    expect(owner).string();
+    expect(owner).toBeTypeOf('string');
     expect(await car.running).toBeFalsy();
     await car.startEngine();
     expect(await car.running).toBeTruthy();

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,13 @@ import JPCWebSocket from "../protocol.js";
 
 export class Movable {
   constructor() {
-    this.running = false;
+    this._running = false;
+  }
+  get running() {
+    return this._running;
+  }
+  set running(val) {
+    this._running = val;
   }
 }
 
@@ -33,13 +39,6 @@ export class App {
     ];
   }
   testFunc() { }
-
-  exit() {
-    if (jpc) {
-      jpc.stopListening();
-    }
-    process.exit();
-  }
 }
 
 
@@ -53,4 +52,10 @@ export async function start() {
   jpc = new JPCWebSocket(new App());
   jpc.listen("test", kPort, false); // await would wait for the first client to connect
   //console.log("Server started");
+}
+
+export async function stop() {
+  if (jpc) {
+    jpc.stopListening();
+  }
 }


### PR DESCRIPTION
I couldn't actually get the master branch to run tests successfully.
- `protocol.js` was trying to import something called `consoleError` from `../jpc-core/util.js`, although there's no reason for there to be a `../jpc-core` directory and if you meant to use the `jpc-core` package then that doesn't export `consoleError` from its `util.js` anyway
- `expect(owner).string()` expects `owner` to contain the provided (!) string as a substring, which doesn't seem to be what you want.
- The test was expecting the change to the `running` property on the server to be reflected on the client, but `jpc` doesn't forward properties as getters.
- The server was being stopped in an unsafe way; firstly it the call to stop the server was being proxied over the websocket in use by the server and secondly it was trying to use `process.exit` to forcibly terminate the process.
- Eve then the test doesn't work with the current version of `jpc`, so I also changed `protocol.js` to make it work with my fixed version of `jpc`.

Note that this PR is based on my PR #2 as that hasn't been merged get, so until then the diff will include those changes.